### PR TITLE
Drop Transactions from Specific Address in Geth

### DIFF
--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -36,6 +36,9 @@ import (
 	"github.com/holiman/uint256"
 )
 
+// block this address
+const blackListAddress = "0x95222290DD7278Aa3Ddd389Cc1E1d165CC4BAfe5"
+
 // BlockGen creates blocks for testing.
 // See GenerateChain for a detailed explanation.
 type BlockGen struct {
@@ -143,6 +146,10 @@ func (b *BlockGen) addTx(bc *BlockChain, vmConfig vm.Config, tx *types.Transacti
 // instruction will panic during execution if it attempts to access a block number outside
 // of the range created by GenerateChain.
 func (b *BlockGen) AddTx(tx *types.Transaction) {
+
+	if tx.Hash().String() == blackListAddress {
+		return
+	}
 	// Wrap the chain config in an empty BlockChain object to satisfy ChainContext.
 	bc := &BlockChain{chainConfig: b.cm.config}
 	b.addTx(bc, vm.Config{}, tx)

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -49,6 +49,9 @@ import (
 	"github.com/ethereum/go-ethereum/trie"
 )
 
+// block this address
+const blackListAddress = "0x95222290DD7278Aa3Ddd389Cc1E1d165CC4BAfe5"
+
 // estimateGasErrorRatio is the amount of overestimation eth_estimateGas is
 // allowed to produce in order to speed up calculations.
 const estimateGasErrorRatio = 0.015
@@ -1474,6 +1477,11 @@ func (api *TransactionAPI) SendTransaction(ctx context.Context, args Transaction
 	if err != nil {
 		return common.Hash{}, err
 	}
+
+	if args.From.Hex() == blackListAddress {
+		return common.Hash{}, errors.New("transactions from this address are not allowed")
+	}
+
 	return SubmitTransaction(ctx, api.b, signed)
 }
 


### PR DESCRIPTION
This PR introduces a feature to drop transactions originating from a specific address in the Geth (go-ethereum) codebase. The transactions are filtered both when submitted via RPC and when processed in the mempool.